### PR TITLE
fix(rss): added the blocksUrl parameter

### DIFF
--- a/app/rss.xml/route.ts
+++ b/app/rss.xml/route.ts
@@ -1,4 +1,7 @@
-import { generateRegistryRssFeed } from "@wandry/analytics-sdk";
+import {
+  generateRegistryRssFeed,
+  UrlResolverByItem,
+} from "@wandry/analytics-sdk";
 import type { NextRequest } from "next/server";
 
 export const revalidate = 3600;
@@ -8,6 +11,14 @@ export async function GET(request: NextRequest) {
 
   const rssXml = await generateRegistryRssFeed({
     baseUrl,
+    blocksUrl: ((item) => {
+      /**
+       * This is necessary in order to correctly select the link to the block.
+       * Since you do not have a separate link to the block, but only to the block category,
+       * I made it possible to obtain the category from the block
+       */
+      return `/${item.name.split("-")?.[0] ?? "uncategorized"}`;
+    }) as UrlResolverByItem,
     rss: {
       title: "@blocks",
       description: "Subscribe to @blocks updates",


### PR DESCRIPTION
I added the `blocksUrl` parameter to the function for generating the RSS because right now your RSS contains invalid links: by default the link to a block is `/blocks/...`, while in your case they are all located in the root. In addition, I take the registry item name and insert it into the link, but you don’t have a separate page for each block, so I just generate a link to the block category.

Have you considered adding a # parameter to the link, for example: https://blocks.so/ai#ai-02 and scroll to the required block; in this case, you don't need separate pages for each block, but you would still have a link that points directly to each block