### PR TITLE
Mobile Container Fix for Registry Component

### DIFF
--- a/components/registry-setup.tsx
+++ b/components/registry-setup.tsx
@@ -60,7 +60,7 @@ export function RegistrySetup({
           Registry
         </Button>
       </DialogTrigger>
-      <DialogContent className="md:max-w-2xl">
+      <DialogContent className="md:max-w-2xl flex flex-col">
         <DialogHeader>
           <DialogTitle>Setup Registry</DialogTitle>
           <DialogDescription>


### PR DESCRIPTION
This update includes a corrected mobile version of the Registry component’s container layout. The fix ensures proper spacing, alignment, and responsive behavior across all screen sizes.

Before:
<img width="421" height="1040" alt="image" src="https://github.com/user-attachments/assets/f55bac95-5e08-4602-9cd0-605ef9dcb162" />

After:
<img width="419" height="1042" alt="image" src="https://github.com/user-attachments/assets/a898e8a9-eea0-4446-a0a4-b00133594fef" />