### PR TITLE
chore: auto-manage CodeRabbit label

### DIFF
--- a/.github/workflows/coderabbit-flag.yml
+++ b/.github/workflows/coderabbit-flag.yml
@@ -1,0 +1,13 @@
+name: CodeRabbit Flag (caller)
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  pull-requests: read
+  issues: write
+
+jobs:
+  flag:
+    uses: aleaguilar/coderabbit/.github/workflows/coderabbit-flag.yml@main


### PR DESCRIPTION
- Add a lightweight workflow that applies/removes `coderabbit` based on PR file-count (<= 200, excluding `*.md`)
- Remove repo-local `.coderabbit.*` so CodeRabbit inherits org-wide config from `aleaguilar/coderabbit`

Notes:
- Uses `pull_request_target` but does not check out PR code (label-only).

Made with [Cursor](https://cursor.com)