### PR TITLE
fix: correct mismatched titles and descriptions in dialog-07 and dialog-08 registry blocks

### DIFF
--- a/public/r/dialog-07.json
+++ b/public/r/dialog-07.json
@@ -2,8 +2,8 @@
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "dialog-07",
   "type": "registry:block",
-  "title": "Dialog with Member List",
-  "description": "A dialog with member list block.",
+  "title": "Dialog with Email and Password Fields",
+  "description": "A dialog with email and password fields block.",
   "author": "ephraim duncan <https://ephraimduncan.com>",
   "registryDependencies": [
     "alert-dialog",

--- a/public/r/dialog-08.json
+++ b/public/r/dialog-08.json
@@ -2,8 +2,8 @@
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "dialog-08",
   "type": "registry:block",
-  "title": "Dialog with Email and Password Fields",
-  "description": "A dialog with email and password fields block.",
+  "title": "Dialog with Member List",
+  "description": "A dialog with member list block.",
   "author": "ephraim duncan <https://ephraimduncan.com>",
   "registryDependencies": [
     "avatar",


### PR DESCRIPTION
## Summary
Fixes a copy-paste swap where `dialog-07` and `dialog-08` had their `title` and `description` fields swapped in the registry JSON files.

## Changes
- `dialog-07.json`: Title/description corrected to **"Dialog with Email and Password Fields"**
- `dialog-08.json`: Title/description corrected to **"Dialog with Member List"**

## Root Cause
The `title` and `description` values were swapped between the two files — `dialog-07` was showing the member list label while `dialog-08` was showing the email/password label.

## Type
- [x] Bug fix (non-breaking)