### PR TITLE
chore: rename @blocks registry namespace to @blocks-so

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ To use blocks from this registry, configure your `components.json` file with the
 ```json
 {
   "registries": {
-    "@blocks": "https://blocks.so/r/{name}.json"
+    "@blocks-so": "https://blocks.so/r/{name}.json"
   }
 }
 ```
@@ -20,13 +20,13 @@ Then add blocks to your project using the shadcn CLI:
 
 ```bash
 # Add a specific block
-npx shadcn@latest add @blocks/login-01
+npx shadcn@latest add @blocks-so/login-01
 
 # Add a dialog block
-npx shadcn@latest add @blocks/dialog-01
+npx shadcn@latest add @blocks-so/dialog-01
 
 # Add a sidebar block
-npx shadcn@latest add @blocks/sidebar-01
+npx shadcn@latest add @blocks-so/sidebar-01
 ```
 
 Alternatively, you can add blocks directly from the registry:

--- a/app/(blocks)/[blocksCategory]/[blockId]/page.tsx
+++ b/app/(blocks)/[blocksCategory]/[blockId]/page.tsx
@@ -155,7 +155,7 @@ export default async function BlockPage({ params }: Params) {
             Add this block to your project with the shadcn CLI.
           </p>
           <pre className="mt-4 overflow-x-auto rounded-md border bg-background px-4 py-3 text-sm">
-            <code>{`npx shadcn@latest add @blocks/${block.blocksId}`}</code>
+            <code>{`npx shadcn@latest add @blocks-so/${block.blocksId}`}</code>
           </pre>
         </section>
 

--- a/components/add-command.tsx
+++ b/components/add-command.tsx
@@ -19,7 +19,7 @@ export function AddCommand({
     <Button
       className="rounded-lg pl-2!"
       onClick={() => {
-        copyToClipboard(`npx shadcn@latest add @blocks/${name}`);
+        copyToClipboard(`npx shadcn@latest add @blocks-so/${name}`);
         toast.success('npx command copied to clipboard');
         posthog.capture('registry_install_clicked', {
           block_id: name,
@@ -62,7 +62,7 @@ export function AddCommand({
           />
         </svg>
       )}
-      {`@blocks/${name}`}
+      {`@blocks-so/${name}`}
     </Button>
   );
 }

--- a/components/registry-setup.tsx
+++ b/components/registry-setup.tsx
@@ -66,7 +66,7 @@ export function RegistrySetup({
         <DialogHeader>
           <DialogTitle>Setup Registry</DialogTitle>
           <DialogDescription>
-            Use the code below to configure the @blocks registry for your
+            Use the code below to configure the @blocks-so registry for your
             project.
           </DialogDescription>
         </DialogHeader>
@@ -99,7 +99,7 @@ export function RegistrySetup({
         </div>
         <div className="min-h-[50px] overflow-x-auto rounded-md bg-muted p-8">
           <pre className="font-mono text-sm">
-            <code>npx shadcn@latest add @blocks/[component-name]</code>
+            <code>npx shadcn@latest add @blocks-so/[component-name]</code>
           </pre>
         </div>
         <div className="font-medium">
@@ -116,6 +116,6 @@ export function RegistrySetup({
 }
 
 const registrySetupCode = `"registries": {
-  "@blocks": "https://blocks.so/r/{name}.json"
+  "@blocks-so": "https://blocks.so/r/{name}.json"
 }
 `;

--- a/scripts/generate-rss.ts
+++ b/scripts/generate-rss.ts
@@ -74,9 +74,9 @@ const items = registry.items
 const rss = `<?xml version="1.0" encoding="UTF-8"?>
 <rss version="2.0">
   <channel>
-    <title>@blocks</title>
+    <title>@blocks-so</title>
     <link>https://blocks.so</link>
-    <description>Subscribe to @blocks updates</description>
+    <description>Subscribe to @blocks-so updates</description>
     <lastBuildDate>${new Date().toUTCString()}</lastBuildDate>
 ${items}
   </channel>


### PR DESCRIPTION
## Summary
- The `@blocks` shadcn registry namespace has been taken, so rename to `@blocks-so` across all source files
- Updated README, registry setup dialog, add-command button, block detail page install snippet, and RSS feed metadata
- `public/r/` files are auto-generated and not changed in this PR

## Test plan
- [ ] Run `bun run generate:registry` and `bun run generate:markdown` to verify regeneration works
- [ ] Verify registry setup dialog shows `@blocks-so` namespace
- [ ] Verify copy-to-clipboard commands use `@blocks-so/` prefix
- [ ] Grep for stale `@blocks/` or `"@blocks"` references