### PR TITLE
feat(blocks): align preview toolbar controls

### DIFF
--- a/components/add-command.tsx
+++ b/components/add-command.tsx
@@ -10,12 +10,11 @@ export function AddCommand({ name }: { name: string }) {
 
   return (
     <Button
-      className="rounded-lg pl-2!"
+      className="pl-2"
       onClick={() => {
         copyToClipboard(`npx shadcn@latest add @blocks-so/${name}`);
         toast.success('npx command copied to clipboard');
       }}
-      size="sm"
       variant="outline"
     >
       {isCopied ? (

--- a/components/open-in-playground-button.tsx
+++ b/components/open-in-playground-button.tsx
@@ -10,11 +10,7 @@ export function OpenInPlaygroundButton({
   return (
     <a
       aria-label="Open in shadcn playground"
-      className={cn(
-        buttonVariants(),
-        'h-8 gap-1 rounded-lg bg-black text-white hover:bg-black hover:text-white dark:bg-white dark:text-black',
-        className
-      )}
+      className={cn(buttonVariants({ variant: 'outline' }), 'gap-1', className)}
       data-umami-event="Open Block in Playground"
       href={`https://play.blocks.so/api/open?url=${
         process.env.NEXT_PUBLIC_BASE_URL || 'https://blocks.so'

--- a/components/open-in-v0-button.tsx
+++ b/components/open-in-v0-button.tsx
@@ -10,11 +10,7 @@ export function OpenInV0Button({
   return (
     <a
       aria-label="Open in v0"
-      className={cn(
-        buttonVariants(),
-        'h-8 gap-1 rounded-lg bg-black text-white hover:bg-black hover:text-white dark:bg-white dark:text-black',
-        className
-      )}
+      className={cn(buttonVariants(), 'gap-1', className)}
       data-umami-event="Open Block in v0"
       href={`https://v0.dev/chat/api/open?url=${
         process.env.NEXT_PUBLIC_BASE_URL || 'https://blocks.so'

--- a/components/ui/block.tsx
+++ b/components/ui/block.tsx
@@ -30,6 +30,9 @@ interface BlockViewState {
 const CODE_BLOCK_REGEX = /`{3,4}(?:[a-zA-Z0-9#+-]+)?\n([\s\S]*?)`{3,4}/;
 const CODE_LANG_REGEX = /^`{3,4}([a-zA-Z0-9#+-]+)\n/;
 
+const sizeItem =
+  'h-full w-6.5 min-w-0 rounded-md p-0 text-foreground/60 hover:text-foreground aria-pressed:bg-background aria-pressed:text-foreground aria-pressed:shadow-sm dark:aria-pressed:border dark:aria-pressed:border-input dark:aria-pressed:bg-input/30';
+
 const CodeBlockEditor = dynamic(
   () => import('../code-block-editor').then((mod) => mod.CodeBlockEditor),
   { ssr: false }
@@ -183,22 +186,22 @@ export const Block = ({
           {name}
         </Link>
 
-        <div className="flex flex-wrap items-center gap-1.5">
+        <div className="flex flex-wrap items-center gap-2">
           <Tabs
             className="hidden lg:flex"
             onValueChange={handleViewChange}
             value={state.view}
           >
-            <TabsList className="h-8 rounded-lg">
+            <TabsList>
               <TabsTrigger
-                className="h-7 rounded-md px-2.5"
+                className="px-2.5"
                 data-umami-event="View Block Preview"
                 value="preview"
               >
                 Preview
               </TabsTrigger>
               <TabsTrigger
-                className="h-7 rounded-md px-2.5"
+                className="px-2.5"
                 data-umami-event="View Block Code"
                 value="code"
               >
@@ -207,9 +210,9 @@ export const Block = ({
             </TabsList>
           </Tabs>
 
-          <div className="ml-auto hidden h-8 items-center gap-0.5 rounded-lg bg-zinc-50 p-1 ring-1 ring-black/5 lg:flex">
+          <div className="hidden h-8 items-center gap-0.5 rounded-lg bg-muted p-[3px] lg:flex">
             <ToggleGroup
-              className="gap-0.5"
+              className="h-full gap-0.5"
               onValueChange={(value) => {
                 const size = value[0];
                 if (size) {
@@ -219,7 +222,7 @@ export const Block = ({
               value={[state.size]}
             >
               <ToggleGroupItem
-                className="size-6 min-w-0 rounded-md p-0"
+                className={sizeItem}
                 data-umami-event="Set Preview Desktop"
                 title="Desktop"
                 value="desktop"
@@ -227,7 +230,7 @@ export const Block = ({
                 <Monitor className="size-3.5" />
               </ToggleGroupItem>
               <ToggleGroupItem
-                className="size-6 min-w-0 rounded-md p-0"
+                className={sizeItem}
                 data-umami-event="Set Preview Tablet"
                 title="Tablet"
                 value="tablet"
@@ -235,7 +238,7 @@ export const Block = ({
                 <Tablet className="size-3.5" />
               </ToggleGroupItem>
               <ToggleGroupItem
-                className="size-6 min-w-0 rounded-md p-0"
+                className={sizeItem}
                 data-umami-event="Set Preview Mobile"
                 title="Mobile"
                 value="mobile"
@@ -244,12 +247,12 @@ export const Block = ({
               </ToggleGroupItem>
             </ToggleGroup>
 
-            <Separator className="h-4" orientation="vertical" />
+            <Separator className="mx-0.5 h-4" orientation="vertical" />
 
             <Link
               className={cn(
                 buttonVariants({ variant: 'ghost', size: 'icon' }),
-                'size-6 rounded-md p-0'
+                'h-full w-6.5 rounded-md text-foreground/60 hover:text-foreground'
               )}
               data-umami-event="Open Block Fullscreen Preview"
               href={`/preview/${blocksId}`}
@@ -262,86 +265,61 @@ export const Block = ({
             </Link>
           </div>
 
-          <Separator
-            className="mx-0.5 hidden h-4 md:flex"
-            orientation="vertical"
-          />
+          <Separator className="hidden h-4 lg:block" orientation="vertical" />
 
           <AddCommand name={blocksId} />
 
-          <Separator
-            className="mx-0.5 hidden h-4 xl:flex"
-            orientation="vertical"
-          />
-
-          <div className="flex items-center gap-1.5">
-            {meta?.type === 'file' && (
-              <OpenInPlaygroundButton name={blocksId} />
-            )}
-            <OpenInV0Button name={blocksId} />
-          </div>
+          {meta?.type === 'file' && <OpenInPlaygroundButton name={blocksId} />}
+          <OpenInV0Button name={blocksId} />
         </div>
       </div>
 
       <div className="relative mt-4 w-full">
         {state.view === 'preview' && (
-          <div className="md:h-(--height)">
-            <div className="grid w-full gap-4">
-              <ResizablePanelGroup
-                className="relative z-10"
-                orientation="horizontal"
-              >
-                <ResizablePanel
-                  className="relative"
-                  defaultSize={100}
-                  minSize={30}
-                  panelRef={resizablePanelRef}
-                >
-                  {InlineBlock ? (
-                    <div
-                      className="overflow-auto rounded-2xl border border-black/10 bg-background"
-                      style={{ height: iframeHeight }}
-                    >
-                      <div className="flex min-h-full w-full items-center justify-center [&_.min-h-dvh]:min-h-0">
-                        <InlineBlock />
-                      </div>
-                    </div>
-                  ) : (
-                    <div
-                      className="h-full overflow-hidden rounded-2xl border border-black/10"
-                      ref={watchFrame}
-                      style={{ height: iframeHeight }}
-                    >
-                      {showFrame && (
-                        <iframe
-                          className="relative z-20 w-full bg-background"
-                          height={meta?.iframeHeight ?? 930}
-                          src={`/preview/${blocksId}`}
-                          title={`${name} preview`}
-                        />
-                      )}
-                    </div>
+          <ResizablePanelGroup
+            className="md:h-(--height)"
+            orientation="horizontal"
+          >
+            <ResizablePanel
+              className="overflow-hidden rounded-2xl border border-black/10 bg-background dark:border-white/10"
+              defaultSize={100}
+              minSize={30}
+              panelRef={resizablePanelRef}
+            >
+              {InlineBlock ? (
+                <div className="overflow-auto" style={{ height: iframeHeight }}>
+                  <div className="flex min-h-full w-full items-center justify-center [&_.min-h-dvh]:min-h-0">
+                    <InlineBlock />
+                  </div>
+                </div>
+              ) : (
+                <div ref={watchFrame} style={{ height: iframeHeight }}>
+                  {showFrame && (
+                    <iframe
+                      className="w-full bg-background"
+                      height={meta?.iframeHeight ?? 930}
+                      src={`/preview/${blocksId}`}
+                      title={`${name} preview`}
+                    />
                   )}
-                </ResizablePanel>
-                <ResizableHandle className="after:-translate-y-1/2 after:-translate-x-px relative hidden w-3 bg-transparent p-0 after:absolute after:top-1/2 after:right-0 after:h-8 after:w-[6px] after:rounded-full after:bg-border after:transition-all after:hover:h-10 md:block" />
-                <ResizablePanel defaultSize={0} minSize={0} />
-              </ResizablePanelGroup>
-            </div>
-          </div>
+                </div>
+              )}
+            </ResizablePanel>
+            <ResizableHandle className="after:-translate-y-1/2 relative hidden w-3 bg-transparent p-0 after:absolute after:top-1/2 after:left-1/2 after:h-8 after:w-1.5 after:rounded-full after:bg-border after:transition-[height,background-color] after:hover:h-10 after:hover:bg-foreground/30 md:block" />
+            <ResizablePanel defaultSize={0} minSize={0} />
+          </ResizablePanelGroup>
         )}
 
         {state.view === 'code' && meta?.type === 'file' && (
-          <div className="group-data-[view=preview]/block-view-wrapper:hidden">
-            <SingleFileCodeView
-              code={activeSingleFileCode.code}
-              fileName={activeSingleFileCode.fileName}
-              language={activeSingleFileCode.language}
-            />
-          </div>
+          <SingleFileCodeView
+            code={activeSingleFileCode.code}
+            fileName={activeSingleFileCode.fileName}
+            language={activeSingleFileCode.language}
+          />
         )}
 
         {state.view === 'code' && meta?.type === 'directory' && (
-          <div className="overflow-auto rounded-lg group-data-[view=preview]/block-view-wrapper:hidden md:h-(--height)">
+          <div className="overflow-auto rounded-lg md:h-(--height)">
             <CodeBlockEditor blockTitle={name} fileTree={fileTree ?? []} />
           </div>
         )}

--- a/components/ui/separator.tsx
+++ b/components/ui/separator.tsx
@@ -12,7 +12,7 @@ function Separator({
   return (
     <SeparatorPrimitive
       className={cn(
-        'shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch',
+        'shrink-0 self-center bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px',
         className
       )}
       data-slot="separator"


### PR DESCRIPTION
The block toolbar now shows the selected device size. Before this change, the selected size had the same color as its container, so the user could not see which size was active. All controls in the row now have the same height and sit on one baseline, and the vertical dividers sit in the middle of the row.

The v0 button is the only primary button in the row. The Playground button is an outline button.

The vertical Separator now uses self-center in place of self-stretch. The button group separator sets self-stretch itself, so it is not affected.

I examined the toolbar in the browser at the desktop, tablet, and mobile sizes in light mode and in dark mode.