### PR TITLE
fix(seo): shorten page titles and let crawlers read the preview noindex tag

### DIFF
--- a/app/(site)/(blocks)/[blocksCategory]/[blockId]/page.tsx
+++ b/app/(site)/(blocks)/[blocksCategory]/[blockId]/page.tsx
@@ -40,8 +40,8 @@ export async function generateMetadata(props: Params): Promise<Metadata> {
 
   const blockName = block.name;
   const categoryName = category.name;
-  const title = `${blockName} - Free ${categoryName} shadcn/ui component`;
-  const description = `Copy and paste ${blockName} from blocks.so. A free ${categoryName.toLowerCase()} shadcn/ui block built with React, Tailwind CSS, and Next.js.`;
+  const title = `${blockName} - Free Shadcn ${categoryName} Example`;
+  const description = `${blockName}: a free shadcn/ui ${categoryName.toLowerCase()} example with copy-paste React, Tailwind CSS, and Next.js code. Add it from the blocks.so registry.`;
   const canonicalPath = `/${params.blocksCategory}/${params.blockId}`;
 
   return {

--- a/app/(site)/(blocks)/[blocksCategory]/page.tsx
+++ b/app/(site)/(blocks)/[blocksCategory]/page.tsx
@@ -31,8 +31,8 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const blockCount = blocksCategory.count || 0;
 
   return {
-    title: `${categoryName} Shadcn Blocks - ${blockCount} Free shadcn/ui ${categoryName} Components`,
-    description: `Free shadcn/ui ${categoryName.toLowerCase()} blocks and components built with React, Tailwind CSS, and Next.js. Copy and paste ${blockCount} beautifully designed, accessible ${categoryName.toLowerCase()} UI blocks into your projects.`,
+    title: `Shadcn ${categoryName} Components - ${blockCount} Free Examples`,
+    description: `${blockCount} free shadcn/ui ${categoryName.toLowerCase()} examples with copy-paste React, Tailwind CSS, and Next.js code. Open source and accessible.`,
     alternates: { canonical: `/${categoryId}` },
     keywords: [
       `shadcn ${categoryName.toLowerCase()}`,
@@ -112,6 +112,11 @@ export default async function Page({ params }: PageProps) {
           <h1 className="text-balance font-semibold text-3xl tracking-tight sm:text-4xl md:text-5xl">
             {blocks.name}
           </h1>
+          <p className="text-pretty text-base text-zinc-500 md:text-lg">
+            {blocks.blocksData.length} free shadcn/ui {blocks.name.toLowerCase()}{' '}
+            examples built with React, Tailwind CSS, and Next.js. Copy the code
+            or add any block from the registry.
+          </p>
         </div>
 
         <div className="overflow-hidden px-px pb-px">

--- a/app/(site)/layout.tsx
+++ b/app/(site)/layout.tsx
@@ -14,7 +14,7 @@ export const metadata: Metadata = {
   applicationName: 'blocks.so',
   title: {
     default: 'Shadcn Blocks - 60+ Free shadcn/ui Components for React',
-    template: '%s | blocks.so - shadcn/ui blocks',
+    template: '%s | blocks.so',
   },
   description: siteConfig.description,
   keywords: [

--- a/app/robots.txt
+++ b/app/robots.txt
@@ -1,7 +1,6 @@
 User-agent: *
 Allow: /
 Disallow: /private/
-Disallow: /preview/
 Disallow: /demo/
 
 Sitemap: https://blocks.so/sitemap.xml


### PR DESCRIPTION
Search results now show a short title for each category page and block page, and the preview pages will drop out of the Google index.

Search Console data for the last three months shows that the category pages rank at position 5 to 8 but get approximately 2% of clicks. Google cut the titles off because the titles were approximately 95 characters long. A category title is now `Shadcn File Upload Components - 6 Free Examples | blocks.so`. Many queries at position 2 to 5 contain the word "example" and got zero clicks, thus the new titles and descriptions contain that word.

Google indexed some preview pages although the preview layout sets a `noindex` tag. The `Disallow: /preview/` line in `robots.txt` blocked the crawler before the crawler could read the tag. The line is removed, and the tag now applies.

The type check passed.